### PR TITLE
fix: lower the cpu_architecture string

### DIFF
--- a/fastapi_tailwind/__init__.py
+++ b/fastapi_tailwind/__init__.py
@@ -2,4 +2,4 @@
 ✨ TailwindCSS support for 🔥 FastAPI.
 """
 
-__version__ = "1.0.1alpha3"
+__version__ = "1.0.1alpha5"

--- a/fastapi_tailwind/binary.py
+++ b/fastapi_tailwind/binary.py
@@ -20,7 +20,7 @@ binaries_path = Path(__file__).parent.joinpath("binaries")
 
 def get_tailwind_binary_path() -> Optional[Path]:
     path: Optional[Path] = None 
-    cpu_architecture = platform.machine()
+    cpu_architecture = platform.machine().lower()
 
     cpu_architecture = MACHINE_TYPE_TO_TAILWIND_TYPE.get(cpu_architecture, cpu_architecture)
 


### PR DESCRIPTION
This fixes an issue I had when trying to use `fastapi-tailwind` on Windows.

```
FileNotFoundError: Couldn't find the tailwindcss binary for 'Windows'! 'C:\Users\Ananas\scoop\apps\python\current\Lib\site-packages\fastapi_tailwind\binaries\tailwindcss-windows-AMD64.exe' does not exist!
```